### PR TITLE
Improve metrics layout

### DIFF
--- a/udata_metrics/templates/dataset-metrics.html
+++ b/udata_metrics/templates/dataset-metrics.html
@@ -3,7 +3,7 @@
 <section class="fr-pb-3w fr-mb-3w border-bottom border-default-grey vuejs">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--gutters">
         <div class="fr-col">
-            <h2 class="subtitle subtitle--uppercase">{{ _("Statistics") }}</h2>
+            <h2 class="subtitle subtitle--uppercase">{{ _("Statistics for the year") }}</h2>
         </div>
         <div class="fr-col-auto">
             <a class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-download-line fr-btn--icon-left"

--- a/udata_metrics/templates/macros/metrics.html
+++ b/udata_metrics/templates/macros/metrics.html
@@ -2,9 +2,8 @@
 {% set month_values = data.keys()|list %}
 {% set metric_values = data.values()|list %}
 {% set previous_month = metric_values[-3] %}
-{% set current_month = metric_values[-2] %}
-{% set current_month_date = month_values[-2] %}
-{% set change = current_month - previous_month %}
+{% set current_month = metric_values[-1] %}
+{% set current_month_date = month_values[-1] %}
 {% set changes_this_year = metric_values|max is greaterthan 0 %}
 <div class="fr-col-12 fr-col-md-{{col_size}} {% if not value and not changes_this_year %} text-mention-grey {% endif %}">
     <h3 class="fr-text--sm fr-m-0">{{title}}</h3>
@@ -18,10 +17,10 @@
         </div>
         {% endif %}
     </div>
-    {% if current_month and change > 0 %}
-        <p class="fr-mt-1w fr-text--regular text-transform-lowercase fr-badge fr-badge--no-icon fr-badge--success">
+    {% if current_month > 0 %}
+        <p class="fr-mt-1w fr-text--regular text-transform-none fr-badge fr-badge--no-icon fr-badge--success">
             <strong class='fr-mr-1v'>
-                    +{{change | summarize}}
+                    {{current_month | summarize}}
             </strong>
             {{_(" in ")}}
             {{isodate(current_month_date + "-01", format="MMM yyyy")}}

--- a/udata_metrics/templates/organization-metrics.html
+++ b/udata_metrics/templates/organization-metrics.html
@@ -3,7 +3,7 @@
 <section class="fr-pb-3w fr-mb-3w border-bottom border-default-grey vuejs">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--gutters">
         <div class="fr-col">
-            <h2 class="subtitle subtitle--uppercase fr-m-0">{{ _("General statistics") }}</h2>
+            <h2 class="subtitle subtitle--uppercase fr-m-0">{{ _("General statistics for the year") }}</h2>
         </div>
         <div class="fr-col-auto">
             <a class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-download-line fr-btn--icon-left"

--- a/udata_metrics/templates/reuse-metrics.html
+++ b/udata_metrics/templates/reuse-metrics.html
@@ -3,7 +3,7 @@
 <section class="fr-pb-3w fr-my-3w border-bottom border-default-grey vuejs">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--gutters">
         <div class="fr-col">
-            <h2 class="subtitle subtitle--uppercase fr-mb-3v">{{ _("Statistics") }}</h2>
+            <h2 class="subtitle subtitle--uppercase fr-mb-3v">{{ _("Statistics for the year") }}</h2>
         </div>
         <div class="fr-col-auto">
             <a class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-download-line fr-btn--icon-left"

--- a/udata_metrics/templates/site-metrics.html
+++ b/udata_metrics/templates/site-metrics.html
@@ -26,11 +26,11 @@
             {% if download_resource %}
             {{metrics(_("Resource downloads"), download_resource.values()|sum, download_resource, type="line", col_size=4)}}
             {% endif %}
-            {{metrics(_("Datasets"), current_site.metrics['datasets'], dataset_metrics, col_size=4)}}
         </div>
     </section>
     <section>
         <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
+            {{metrics(_("Datasets"), current_site.metrics['datasets'], dataset_metrics, col_size=4)}}
             {{metrics(_("Harvesters"), current_site.metrics['harvesters'], harvest_metrics, col_size=4)}}
             {{metrics(_("Reuses"), current_site.metrics['reuses'], reuse_metrics, col_size=4)}}
         </div>

--- a/udata_metrics/templates/site-metrics.html
+++ b/udata_metrics/templates/site-metrics.html
@@ -4,7 +4,7 @@
 <section class="fr-container fr-mb-16w vuejs">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--gutters">
         <div class="fr-col">
-            <h1 class="fr-h3">{{ _("Metrics") }}</h1>
+            <h1 class="fr-h3">{{ _("Statistics for the year") }}</h1>
         </div>
         <div class="fr-col-auto">
             <a class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-download-line fr-btn--icon-left"

--- a/udata_metrics/translations/udata_metrics.pot
+++ b/udata_metrics/translations/udata_metrics.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-metrics 1.0.3.dev0\n"
+"Project-Id-Version: udata-metrics 2.0.1.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2023-11-20 17:20+0100\n"
-"PO-Revision-Date: 2023-11-20 17:20+0100\n"
+"POT-Creation-Date: 2023-11-30 15:20+0100\n"
+"PO-Revision-Date: 2023-11-30 15:20+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -21,7 +21,8 @@ msgstr ""
 
 #: udata_metrics/templates/dataset-metrics.html:6
 #: udata_metrics/templates/reuse-metrics.html:6
-msgid "Statistics"
+#: udata_metrics/templates/site-metrics.html:7
+msgid "Statistics for the year"
 msgstr ""
 
 #: udata_metrics/templates/dataset-metrics.html:11
@@ -55,11 +56,11 @@ msgid "Followers"
 msgstr ""
 
 #: udata_metrics/templates/organization-metrics.html:6
-msgid "General statistics"
+msgid "General statistics for the year"
 msgstr ""
 
 #: udata_metrics/templates/organization-metrics.html:16
-#: udata_metrics/templates/site-metrics.html:29
+#: udata_metrics/templates/site-metrics.html:33
 msgid "Datasets"
 msgstr ""
 
@@ -78,10 +79,6 @@ msgstr ""
 
 #: udata_metrics/templates/organization-metrics.html:30
 msgid "Reuses statistics"
-msgstr ""
-
-#: udata_metrics/templates/site-metrics.html:7
-msgid "Metrics"
 msgstr ""
 
 #: udata_metrics/templates/site-metrics.html:18
@@ -112,7 +109,7 @@ msgstr ""
 msgid "Discussions"
 msgstr ""
 
-#: udata_metrics/templates/macros/metrics.html:26
+#: udata_metrics/templates/macros/metrics.html:25
 msgid " in "
 msgstr ""
 


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/1205

* Specify that statistics are for the year
* Move datasets graph on the second row in dashboard stats
* Use current month value (and not variation)
* Prevent upper or lowercasing by removing any text transformation

Need https://github.com/etalab/udata-front/pull/325 that introduces `text-transform-none` style.
