### PR TITLE
Improve metrics task and add downloads to datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Migrate to Python 3.11 following `udata` dependencies upgrade [#14](https://github.com/opendatateam/udata-metrics/pull/14)
+- Add `resources_downloads` to datasets metrics and refactor `update_metrics_for_models` task [#15](https://github.com/opendatateam/udata-metrics/pull/15)
 
 ## 2.0.2 (2024-03-20)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,18 @@
 from datetime import datetime, timedelta
 
 
+def mock_metrics_api(app, rmock, endpoint, value_key, values):
+    url = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page_size=50'
+    rmock.get(url, json={
+        'data': values,
+        'links': {
+            'next': None
+        },
+        'meta': {
+            'total': len(values)
+        }
+    })
+
 def mock_metrics_payload(app, rmock, target, value_key, data, url=None, next=None, total=10):
     if not url:
         url = f'{app.config["METRICS_API"]}/{target}_total/data/?{value_key}__greater=1'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,36 +1,36 @@
 from datetime import datetime, timedelta
 
+def chunks(xs, n):
+    n = max(1, n)
+    return (xs[i:i+n] for i in range(0, len(xs), n))
 
-def mock_metrics_api(app, rmock, endpoint, value_key, values):
-    url = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page_size=50'
-    rmock.get(url, json={
-        'data': values,
-        'links': {
-            'next': None
-        },
-        'meta': {
-            'total': len(values)
-        }
-    })
+def mock_metrics_api(app, rmock, endpoint, value_key, values, page_size: int = 50):
+    chunked = list(chunks(values, page_size))
 
-def mock_metrics_payload(app, rmock, target, value_key, data, url=None, next=None, total=10):
-    if not url:
-        url = f'{app.config["METRICS_API"]}/{target}_total/data/?{value_key}__greater=1'
-    rmock.get(url, json={
-        'data': [
-            {
-                f'{target}_id': key,
-                value_key: value
-            } for key, value in data
-        ],
-        'links': {
-            'next': next
-        },
-        'meta': {
-            'total': total
-        }
-    })
+    next = None
+    for i, chunk in enumerate(chunked):
+        page_number = i + 1
 
+        if next is None:
+            url = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page_size={page_size}'
+        else:
+            url = next
+
+        # Test if we're on the last page
+        if page_number == len(chunked):
+            next = None
+        else:
+            next = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page={page_number + 1}&page_size={page_size}'
+
+        rmock.get(url, json={
+            'data': chunk,
+            'links': {
+                'next': next
+            },
+            'meta': {
+                'total': len(values)
+            }
+        })
 
 def mock_monthly_metrics_payload(app, rmock, target, data, target_id='id', url=None):
     if not url:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 
 def chunks(xs, n):
-    n = max(1, n)
-    return (xs[i:i+n] for i in range(0, len(xs), n))
+    return [xs[i:i+n] for i in range(0, len(xs), n)]
 
 def mock_metrics_api(app, rmock, endpoint, value_key, values, page_size: int = 50):
     chunked = list(chunks(values, page_size))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,33 +3,37 @@ from datetime import datetime, timedelta
 def chunks(xs, n):
     return [xs[i:i+n] for i in range(0, len(xs), n)]
 
-def mock_metrics_api(app, rmock, endpoint, value_key, values, page_size: int = 50):
+def mock_metrics_api(app, rmock, endpoint, value_keys, values, page_size: int = 50):
+    for i, value in enumerate(values):
+        value['__id'] = i
+
     chunked = list(chunks(values, page_size))
 
-    next = None
-    for i, chunk in enumerate(chunked):
-        page_number = i + 1
+    for value_key in value_keys:
+        next = None
+        for i, chunk in enumerate(chunked):
+            page_number = i + 1
 
-        if next is None:
-            url = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page_size={page_size}'
-        else:
-            url = next
+            if next is None:
+                url = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page_size={page_size}'
+            else:
+                url = next
 
-        # Test if we're on the last page
-        if page_number == len(chunked):
-            next = None
-        else:
-            next = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page={page_number + 1}&page_size={page_size}'
+            # Test if we're on the last page
+            if page_number == len(chunked):
+                next = None
+            else:
+                next = f'{app.config["METRICS_API"]}/{endpoint}_total/data/?{value_key}__greater=1&page={page_number + 1}&page_size={page_size}'
 
-        rmock.get(url, json={
-            'data': chunk,
-            'links': {
-                'next': next
-            },
-            'meta': {
-                'total': len(values)
-            }
-        })
+            rmock.get(url, json={
+                'data': chunk,
+                'links': {
+                    'next': next
+                },
+                'meta': {
+                    'total': len(values)
+                }
+            })
 
 def mock_monthly_metrics_payload(app, rmock, target, data, target_id='id', url=None):
     if not url:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,17 +25,17 @@ def test_iterate_on_metrics(app, rmock):
         { 'id': 3 },
     ]
 
-@pytest.mark.parametrize('endpoint,id_key,factory,func', [
-    ("datasets", "dataset_id", DatasetFactory, update_datasets),
-    ("reuses", "reuse_id", ReuseFactory, update_reuses),
-    ("organizations", "organization_id", OrganizationFactory, update_organizations)
+@pytest.mark.parametrize('endpoint,id_key,factory,func,api_key', [
+    ("datasets", "dataset_id", DatasetFactory, update_datasets, 'visit'),
+    ("reuses", "reuse_id", ReuseFactory, update_reuses, 'visit'),
+    ("organizations", "organization_id", OrganizationFactory, update_organizations, 'visit_dataset')
 ])
-def test_update_simple_visit_to_views_metrics(app, rmock, endpoint, id_key, factory, func):
+def test_update_simple_visit_to_views_metrics(app, rmock, endpoint, id_key, factory, func, api_key):
     models = [factory() for i in range(15)]
-    mock_metrics_api(app, rmock, endpoint, "visit", [
-        { id_key: str(models[1].id), 'visit': 42 },
-        { id_key: str(models[3].id), 'visit': 1337 },
-        { id_key: str(models[4].id), 'visit': 2 },
+    mock_metrics_api(app, rmock, endpoint, api_key, [
+        { id_key: str(models[1].id), api_key: 42 },
+        { id_key: str(models[3].id), api_key: 1337 },
+        { id_key: str(models[4].id), api_key: 2 },
     ])
 
     func()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -78,9 +78,9 @@ def test_update_resources_metrics(app, rmock):
     assert dataset_a_with_resources.resources[0].metrics.get('views') == 42
     assert dataset_a_with_resources.resources[1].metrics.get('views') == 1337
     assert dataset_a_with_resources.resources[4].metrics.get('views') == 2
-    assert dataset_a_with_resources.metrics.get('number_of_resources_downloads') == 42 + 1337 + 2
+    assert dataset_a_with_resources.metrics.get('resources_downloads') == 42 + 1337 + 2
 
     assert dataset_b_with_resource.resources[0].metrics.get('views') == 1404
-    assert dataset_b_with_resource.metrics.get('number_of_resources_downloads') == 1404
+    assert dataset_b_with_resource.metrics.get('resources_downloads') == 1404
 
-    assert dataset_without_resource.metrics.get('number_of_resources_downloads') is None
+    assert dataset_without_resource.metrics.get('resources_downloads') is None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,52 +25,25 @@ def test_iterate_on_metrics(app, rmock):
         { 'id': 3 },
     ]
 
-def test_update_datasets_metrics(app, rmock):
-    datasets = [DatasetFactory() for i in range(15)]
-    mock_metrics_api(app, rmock, "datasets", "visit", [
-        { 'dataset_id': str(datasets[1].id), 'visit': 42 },
-        { 'dataset_id': str(datasets[3].id), 'visit': 1337 },
-        { 'dataset_id': str(datasets[4].id), 'visit': 2 },
+@pytest.mark.parametrize('endpoint,id_key,factory,func', [
+    ("datasets", "dataset_id", DatasetFactory, update_datasets),
+    ("reuses", "reuse_id", ReuseFactory, update_reuses),
+    ("organizations", "organization_id", OrganizationFactory, update_organizations)
+])
+def test_update_simple_visit_to_views_metrics(app, rmock, endpoint, id_key, factory, func):
+    models = [factory() for i in range(15)]
+    mock_metrics_api(app, rmock, endpoint, "visit", [
+        { id_key: str(models[1].id), 'visit': 42 },
+        { id_key: str(models[3].id), 'visit': 1337 },
+        { id_key: str(models[4].id), 'visit': 2 },
     ])
 
-    update_datasets()
-    [dataset.reload() for dataset in datasets]
+    func()
+    [model.reload() for model in models]
 
-    assert datasets[1].metrics.get('views') == 42
-    assert datasets[3].metrics.get('views') == 1337
-    assert datasets[4].metrics.get('views') == 2
-
-
-def test_update_reuses_metrics(app, rmock):
-    reuses = [ReuseFactory() for i in range(15)]
-    mock_metrics_api(app, rmock, "reuses", "visit", [
-        { 'reuse_id': str(reuses[1].id), 'visit': 42 },
-        { 'reuse_id': str(reuses[3].id), 'visit': 1337 },
-        { 'reuse_id': str(reuses[4].id), 'visit': 2 },
-    ])
-
-    update_reuses()
-    [reuse.reload() for reuse in reuses]
-
-    assert reuses[1].metrics.get('views') == 42
-    assert reuses[3].metrics.get('views') == 1337
-    assert reuses[4].metrics.get('views') == 2
-
-def test_update_organizations_metrics(app, rmock):
-    organizations = [OrganizationFactory() for i in range(15)]
-    mock_metrics_api(app, rmock, "organizations", "visit", [
-        { 'organization_id': str(organizations[1].id), 'visit': 42 },
-        { 'organization_id': str(organizations[3].id), 'visit': 1337 },
-        { 'organization_id': str(organizations[4].id), 'visit': 2 },
-    ])
-
-    update_organizations()
-    [organization.reload() for organization in organizations]
-
-    assert organizations[1].metrics.get('views') == 42
-    assert organizations[3].metrics.get('views') == 1337
-    assert organizations[4].metrics.get('views') == 2
-
+    assert models[1].metrics.get('views') == 42
+    assert models[3].metrics.get('views') == 1337
+    assert models[4].metrics.get('views') == 2
 
 def test_update_resources_metrics(app, rmock):
     resources = [ResourceFactory() for i in range(5)]

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 def log_timing(func):
     @wraps(func)
     def timeit_wrapper(*args, **kwargs):
-        model = func.__name__.removeprefix('update_')
+        # Better log if we're using Python 3.9
+        model = func.__name__.removeprefix('update_') if hasattr(func.__name__, 'removeprefix') else func.__name__
         log.info(f"Processing {model}…")
         start_time = time.perf_counter()
         result = func(*args, **kwargs)

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -36,12 +36,12 @@ def save_model(model: db.Document, model_id: str, key: str, value: int) -> None:
         log.exception(e)
 
 
-def iterate_on_metrics(target: str, value_key: str) -> dict:
+def iterate_on_metrics(target: str, value_key: str, page_size: int = 50) -> dict:
     '''
     paginate on target endpoint
     '''
     url = f'{current_app.config["METRICS_API"]}/{target}_total/data/'
-    url += f'?{value_key}__greater=1&page_size=50'
+    url += f'?{value_key}__greater=1&page_size={page_size}'
 
     with requests.Session() as session:
         while url is not None:

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -91,7 +91,6 @@ def update_organizations():
 
 def update_metrics_for_models():
     log.info(f"Starting…")
-    print('toto')
     update_datasets()
     update_resources_and_community_resources()
     update_reuses()

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -17,7 +17,9 @@ def log_timing(func):
     @wraps(func)
     def timeit_wrapper(*args, **kwargs):
         # Better log if we're using Python 3.9
-        model = func.__name__.removeprefix('update_') if hasattr(func.__name__, 'removeprefix') else func.__name__
+        name = func.__name__
+        model = name.removeprefix('update_') if hasattr(name, 'removeprefix') else name
+        
         log.info(f"Processing {model}…")
         start_time = time.perf_counter()
         result = func(*args, **kwargs)

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -19,7 +19,7 @@ def log_timing(func):
         # Better log if we're using Python 3.9
         name = func.__name__
         model = name.removeprefix('update_') if hasattr(name, 'removeprefix') else name
-        
+
         log.info(f"Processing {model}…")
         start_time = time.perf_counter()
         result = func(*args, **kwargs)

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -44,7 +44,7 @@ def iterate_on_metrics(target: str, value_keys: List[str], page_size: int = 50) 
     '''
     Yield all elements with not zero values for the keys inside `value_keys`.
     If you pass ['visit', 'download_resource'], it will do a `OR` and get
-    metrics with one of the two values not zero. 
+    metrics with one of the two values not zero.
     '''
     yielded = set()
 
@@ -57,7 +57,7 @@ def iterate_on_metrics(target: str, value_keys: List[str], page_size: int = 50) 
                 r = session.get(url, timeout=10)
                 r.raise_for_status()
                 data = r.json()
-                
+
                 for row in data['data']:
                     if row['__id'] not in yielded:
                         yielded.add(row['__id'])

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -85,11 +85,13 @@ def update_reuses():
 @log_timing
 def update_organizations():
     # We're currently using visit_dataset as global metric for an orga
-    for data in iterate_on_metrics("organizations", "visit"):
-        save_model(Organization, data['organization_id'], 'views', data['visit'])
+    for data in iterate_on_metrics("organizations", "visit_dataset"):
+        save_model(Organization, data['organization_id'], 'views', data['visit_dataset'])
 
 
 def update_metrics_for_models():
+    log.info(f"Starting…")
+    print('toto')
     update_datasets()
     update_resources_and_community_resources()
     update_reuses()

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import Dict, List
 import requests
 from functools import wraps
 import time
@@ -26,7 +26,7 @@ def log_timing(func):
     return timeit_wrapper
 
 
-def save_model(model: db.Document, model_id: str, metrics: dict[str, int]) -> None:
+def save_model(model: db.Document, model_id: str, metrics: Dict[str, int]) -> None:
     try:
         result = model.objects(id=model_id).update(**{
             f'set__metrics__{key}': value for key, value in metrics.items()

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -70,7 +70,7 @@ def update_resources_and_community_resources():
             )
 
     for dataset_id, sum in sum_of_resources_downloads.items():
-        save_model(Dataset, dataset_id, 'number_of_resources_downloads', sum)
+        save_model(Dataset, dataset_id, 'resources_downloads', sum)
 
 @log_timing
 def update_datasets():


### PR DESCRIPTION
- [x] ~Unrefactor tests~ (revert in d59ced4)
- [x] Remove duplicate in `iterate_on_metrics`
- [x] `save_model` now set directly in database without fetching first
- [x] Unrefactor `process_metrics_result` to allow cleaner separation between simple models (datasets, reuses and organization) and more complex one (resources)
- [x] Add `number_of_resources_downloads` to datasets' metrics

Fix https://github.com/datagouv/data.gouv.fr/issues/1339