### PR TITLE
Compute dataservices metrics in update-metrics job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 parameters:
   python-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,19 @@
 ---
 version: 2
 
+parameters:
+  python-version:
+    type: string
+    default: "3.11"
+  publish-branch:
+    type: string
+    default: "master"
+    description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
+
 jobs:
   build:
     docker:
-      - image: udata/circleci:2-alpine
+      - image: udata/circleci:py<< pipeline.parameters.python-version >>
       - image: mongo:6.0.4
       - image: redis:alpine
     environment:
@@ -98,7 +107,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - << pipeline.parameters.publish-branch >>
                 - /[0-9]+(\.[0-9]+)+/
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Compute dataservices metrics in update-metrics job [#16](https://github.com/opendatateam/udata-metrics/pull/16)
 
 ## 2.0.3 (2024-05-28)
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,2 +1,2 @@
-udata>=6.0.0
-udata-front>=3.2.8
+udata>=8.0.1
+udata-front>=4.0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 import pytest
 
+from udata.core.dataservices.factories import DataserviceFactory
+from udata.core.dataservices.models import Dataservice
 from udata.core.dataset.factories import DatasetFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
@@ -14,6 +16,7 @@ from .helpers import mock_monthly_metrics_payload
 
 @pytest.mark.parametrize('target,value_keys', [
     ('dataset', ['visit', 'download_resource']),
+    ('dataservice', ['visit']),
     ('reuse', ['visit']),
     ('organization', ['visit_dataset', 'download_resource', 'visit_reuse'])
 ])
@@ -41,6 +44,7 @@ def test_get_metrics_for_site(app, rmock):
 
 @pytest.mark.parametrize('model,factory,date_label', [
     (Dataset, DatasetFactory, 'created_at_internal'),
+    (Dataservice, DataserviceFactory, 'created_at'),
     (Reuse, ReuseFactory, 'created_at'),
     (Organization, OrganizationFactory, 'created_at')
 ])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,11 +1,12 @@
 import pytest
 
+from udata.core.dataservices.factories import DataserviceFactory
 from udata.core.dataset.factories import CommunityResourceFactory, DatasetFactory, ResourceFactory
 from udata.core.organization.factories import OrganizationFactory
 from udata.core.reuse.factories import ReuseFactory
 
 from udata_metrics.tasks import (
-    iterate_on_metrics, update_datasets, update_organizations, update_resources_and_community_resources, update_reuses
+    iterate_on_metrics, update_dataservices, update_datasets, update_organizations, update_resources_and_community_resources, update_reuses
 )
 from .helpers import mock_metrics_api
 
@@ -26,6 +27,7 @@ def test_iterate_on_metrics(app, rmock):
     ]
 
 @pytest.mark.parametrize('endpoint,id_key,factory,func,api_key', [
+    ("dataservices", "dataservice_id", DataserviceFactory, update_dataservices, 'visit'),
     ("reuses", "reuse_id", ReuseFactory, update_reuses, 'visit'),
     ("organizations", "organization_id", OrganizationFactory, update_organizations, 'visit_dataset')
 ])

--- a/udata_metrics/tasks.py
+++ b/udata_metrics/tasks.py
@@ -6,6 +6,7 @@ import time
 
 from flask import current_app
 
+from udata.core.dataservices.models import Dataservice
 from udata.models import db, CommunityResource, Dataset, Reuse, Organization
 from udata.tasks import job
 
@@ -92,6 +93,14 @@ def update_datasets():
 
 
 @log_timing
+def update_dataservices():
+    for data in iterate_on_metrics("dataservices", ["visit"]):
+        save_model(Dataservice, data['dataservice_id'], {
+            'views': data['visit'],
+        })
+
+
+@log_timing
 def update_reuses():
     for data in iterate_on_metrics("reuses", ["visit"]):
         save_model(Reuse, data['reuse_id'], {
@@ -109,9 +118,10 @@ def update_organizations():
 
 
 def update_metrics_for_models():
-    log.info(f"Starting…")
+    log.info("Starting…")
     update_datasets()
     update_resources_and_community_resources()
+    update_dataservices()
     update_reuses()
     update_organizations()
 


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1559

Following dataservices metrics compute in dedicated DAG (https://github.com/datagouv/datagouvfr_data_pipelines/pull/369).

Needs https://github.com/datagouv/datagouvfr_data_pipelines/pull/446 :heavy_check_mark: 

You can start the job with
```
udata job run update-metrics
```
:warning: the entire metrics update can take quite a lot of time, you may comment out other models except dataservices to test the job out